### PR TITLE
Slate docs

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -15,18 +15,20 @@ search: true
 
 # Introduction
 
-Welcome to the technical documentation for the Material Instinct LLC - DNA Boilerplate.<%= config[:host] %>
+Welcome to the technical documentation for the Material Instinct LLC - DNA Boilerplate.
 
 # Local installation (without Docker)
 
 The platform has 4 parts which need to be installed in this order:  
+
 - DNA Admin  
 - DNA Database  
 - DNA API  
 - DNA Frontend  
+
 You will need access to each individual repository, or you will need to be added to an internal team with the appropriate access privileges.
 
-Requirements: ruby 2.6.2, rails 5.2.2, Postgres
+Requirements: ruby 2.6.2, rails 5.2.2, Postgres, node.js 10.16
 
 ## DNA Admin (Github repo: `dna-admin`)
 
@@ -34,53 +36,83 @@ Admin app for Spree.
 
 Local installation:
 
-1. Make sure you have `ImageMagick` installed; on Mac OSX you can do:  
+- Make sure you have `ImageMagick` installed; on Mac OSX you can do:
+
 `brew install imagemagick`  
+
 Brew will install ImageMagick in a directory similar to the following:   
 `/usr/local/Cellar/imagemagick/7.0.8-49/bin/magick`  
-You can add this dir to your PATH, for instance append the following to your `~/.bashrc` file:  
+
+You can add this dir to your PATH, for instance append the following to your `~/.bashrc` file:
+
 `export PATH=$PATH:/usr/local/Cellar/imagemagick/7.0.8-49/bin`  
-followed by the command  
-`source ~/.bashrc`  
-1. Clone this repo
-1. Copy `.env.example` to `.env.development`
-1. Edit `.env.development`:  
+
+followed by the command `source ~/.bashrc`.
+
+- Clone this repo
+
+- Copy `.env.example` to `.env.development`
+
+- Edit `.env.development`:
+
 Change `DATABASE_PORT` from `2345` to `5432`  
 Change `COMPANY_LOGO` from `path/to/file.png` to `dwell_logo.png`  
-1. Create the PostgreSQL user that we need:  
+
+- Create the PostgreSQL user that we need:
+
 `createuser --pwprompt dna_admin`  
+
 At the prompt, enter the DB password from the `.env.development` file.
-1. Create the PostgreSQL database and assign permissions:  
-`# Login into PostgreSQL with the command line client -`  
-`# replace 'user' with your admin/root user name:`  
+
+- Create the PostgreSQL database and assign permissions:
+
+Login into PostgreSQL with the command line client - replace 'user' with your admin/root user name:
+
 `psql -U user postgres`  
-`# Then, within the psql shell, issue the commands:`  
+
+Then, within the psql shell, issue the commands:
+
 `CREATE DATABASE dna_admin_dev;`  
 `GRANT ALL PRIVILEGES ON DATABASE dna_admin_dev to dna_admin;`  
 `ALTER DATABASE dna_admin_dev owner to dna_admin;`  
+
 **Make sure the database creds (e.g. "dna_admin" in the commands above) match those in `.env.development` !**
-1. Install dependencies:  
+
+- Install dependencies:
+
 `bundle install`
-1. Issue the following rails/rake commands to install Spree (including database data and image assets):  
+
+- Issue the following rails/rake commands to install Spree (including database data and image assets):
+
 `rails g spree:install --user_class=Spree::User`  
 `rails g spree:auth:install`  
 `rails g spree_gateway:install`  
+
 **Notes:**  
+
 While running these `rails g spree` commands, you will receive some warnings:  
+
 `conflict  config/initializers/spree.rb`  
 `Overwrite ...config/initializers/spree.rb? (enter "h" for help) [Ynaqdhm]`  
+
 and  
+
 `conflict  config/initializers/devise.rb`  
 `Overwrite ...config/initializers/devise.rb? (enter "h" for help) [Ynaqdhm]`  
+
 Answer 'Y' to these prompts.  
+
 The command `rails g spree:install --user_class=Spree::User` will also ask for the admin user/password:  
+
 `Create the admin user (press enter for defaults).`  
 `Email [spree@example.com]:`  
 `Password [spree123]:`  
+
 You can accept these defaults (or override them, and remember the values you entered).  
-1. The above `rails g spree` commands have made a few modifications which we don't want - to revert these, do:  
-`git checkout -- config/application.rb config/initializers/spree.rb config/routes.rb \`  
-`  config/initializers/devise.rb vendor/assets/javascripts/spree/frontend/all.js`
+
+- The above `rails g spree` commands have made a few modifications which we don't want - to revert these, do:  
+
+`git checkout -- config/application.rb config/initializers/spree.rb config/routes.rb config/initializers/devise.rb vendor/assets/javascripts/spree/frontend/all.js`
 
 Do not attempt to start the app yet (`rails s`) - we need to complete the database setup first.
 
@@ -90,25 +122,60 @@ This is used to manage (migrations, schema) the single database for all of the o
 
 Local installation:
 
-1. Clone this repo
-1. Copy `.env.example` to `.env.development`
-1. Edit `.env.development`: change `DATABASE_PORT` from `2345` to `5432`
-1. Install dependencies:  
+- Clone this repo
+
+- Copy `.env.example` to `.env.development`
+
+- Edit `.env.development`: change `DATABASE_PORT` from `2345` to `5432`
+
+- Install dependencies:
+
 `bundle install`
-1. Issue the following rake command:  
+
+- Issue the following rake command:
+
 `rake db:migrate`  
 
 ## DNA API (Github repo: `dna-api`)
 
 Local installation:
 
-1. Clone this repo
-1. Copy `.env.example` to `.env.development`
-1. Edit `.env.development`:  
+- Clone this repo
+
+- Copy `.env.example` to `.env.development`
+
+- Edit `.env.development`:
+
 Change `DATABASE_PORT` from `2345` to `5432`  
 Give PUSHER_APP some value, e.g. `PUSHER_APP_ID=foo` (otherwise the app won't start)  
-1. Install dependencies:  
+
+- Install dependencies:
+
 `bundle install`
+
+## DNA Frontend (Github repo: `dna-frontend`)
+
+Local installation:
+
+- Clone this repo
+
+- Copy `.env.example` to `.env`
+
+(the env vars in .env aren't used yet, but if `.env` is missing then you will get a warning when running  `yarn start:dev`)
+
+- Install dependencies:
+
+`yarn`
+
+- Run it:
+
+`yarn start:dev`
+
+*Note:*
+
+If you have the backend (dna-admin or dna-api) running, then you will likely run into a port conflict, because they are also using port 3000. To work around this, run the frontend on another port, e.g:
+
+`PORT=3002 yarn start:dev`
 
 ## Testing your installation
 
@@ -127,6 +194,5 @@ You can enter `rails routes` on the command line to see which routes the API sup
 
 `http://localhost:3001/v1/products`
 
-to get a complete listing of products from the Spree product catalog. The reason why this work is simply a "resource route" definition for Products in `config/routes.rb`, which then generates a set of CRUD routes on the product table.
-
+to get a complete listing of products from the Spree product catalog. The reason why this work is simply a "resource route" definition for Products in `config/routes.rb`, which then generates a set of CRUD routes on the product table.  
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1,5 +1,5 @@
 ---
-title: API Reference
+title: DNA Docs
 
 language_tabs: # must be one of https://git.io/vQNgJ
   - shell
@@ -8,232 +8,125 @@ language_tabs: # must be one of https://git.io/vQNgJ
   - javascript
 
 toc_footers:
-  - <a href='#'>Sign Up for a Developer Key</a>
   - <a href='https://github.com/lord/slate'>Documentation Powered by Slate</a>
-
-includes:
-  - errors
 
 search: true
 ---
 
 # Introduction
 
-Welcome to the Kittn API! You can use our API to access Kittn API endpoints, which can get information on various cats, kittens, and breeds in our database.
+Welcome to the technical documentation for the Material Instinct LLC - DNA Boilerplate.<%= config[:host] %>
+
+# Local installation (without Docker)
+
+The platform has 4 parts which need to be installed in this order:  
+- DNA Admin  
+- DNA Database  
+- DNA API  
+- DNA Frontend  
+You will need access to each individual repository, or you will need to be added to an internal team with the appropriate access privileges.
+
+Requirements: ruby 2.6.2, rails 5.2.2, Postgres
+
+## DNA Admin (Github repo: `dna-admin`)
+
+Admin app for Spree.
+
+Local installation:
+
+1. Make sure you have `ImageMagick` installed; on Mac OSX you can do:  
+`brew install imagemagick`  
+Brew will install ImageMagick in a directory similar to the following:   
+`/usr/local/Cellar/imagemagick/7.0.8-49/bin/magick`  
+You can add this dir to your PATH, for instance append the following to your `~/.bashrc` file:  
+`export PATH=$PATH:/usr/local/Cellar/imagemagick/7.0.8-49/bin`  
+followed by the command  
+`source ~/.bashrc`  
+1. Clone this repo
+1. Copy `.env.example` to `.env.development`
+1. Edit `.env.development`:  
+Change `DATABASE_PORT` from `2345` to `5432`  
+Change `COMPANY_LOGO` from `path/to/file.png` to `dwell_logo.png`  
+1. Create the PostgreSQL user that we need:  
+`createuser --pwprompt dna_admin`  
+At the prompt, enter the DB password from the `.env.development` file.
+1. Create the PostgreSQL database and assign permissions:  
+`# Login into PostgreSQL with the command line client -`  
+`# replace 'user' with your admin/root user name:`  
+`psql -U user postgres`  
+`# Then, within the psql shell, issue the commands:`  
+`CREATE DATABASE dna_admin_dev;`  
+`GRANT ALL PRIVILEGES ON DATABASE dna_admin_dev to dna_admin;`  
+`ALTER DATABASE dna_admin_dev owner to dna_admin;`  
+**Make sure the database creds (e.g. "dna_admin" in the commands above) match those in `.env.development` !**
+1. Install dependencies:  
+`bundle install`
+1. Issue the following rails/rake commands to install Spree (including database data and image assets):  
+`rails g spree:install --user_class=Spree::User`  
+`rails g spree:auth:install`  
+`rails g spree_gateway:install`  
+**Notes:**  
+While running these `rails g spree` commands, you will receive some warnings:  
+`conflict  config/initializers/spree.rb`  
+`Overwrite ...config/initializers/spree.rb? (enter "h" for help) [Ynaqdhm]`  
+and  
+`conflict  config/initializers/devise.rb`  
+`Overwrite ...config/initializers/devise.rb? (enter "h" for help) [Ynaqdhm]`  
+Answer 'Y' to these prompts.  
+The command `rails g spree:install --user_class=Spree::User` will also ask for the admin user/password:  
+`Create the admin user (press enter for defaults).`  
+`Email [spree@example.com]:`  
+`Password [spree123]:`  
+You can accept these defaults (or override them, and remember the values you entered).  
+1. The above `rails g spree` commands have made a few modifications which we don't want - to revert these, do:  
+`git checkout -- config/application.rb config/initializers/spree.rb config/routes.rb \`  
+`  config/initializers/devise.rb vendor/assets/javascripts/spree/frontend/all.js`
+
+Do not attempt to start the app yet (`rails s`) - we need to complete the database setup first.
+
+## DNA Database (Github repo: `dna-database`)
+
+This is used to manage (migrations, schema) the single database for all of the other apps.
+
+Local installation:
+
+1. Clone this repo
+1. Copy `.env.example` to `.env.development`
+1. Edit `.env.development`: change `DATABASE_PORT` from `2345` to `5432`
+1. Install dependencies:  
+`bundle install`
+1. Issue the following rake command:  
+`rake db:migrate`  
+
+## DNA API (Github repo: `dna-api`)
+
+Local installation:
+
+1. Clone this repo
+1. Copy `.env.example` to `.env.development`
+1. Edit `.env.development`:  
+Change `DATABASE_PORT` from `2345` to `5432`  
+Give PUSHER_APP some value, e.g. `PUSHER_APP_ID=foo` (otherwise the app won't start)  
+1. Install dependencies:  
+`bundle install`
+
+## Testing your installation
+
+Move into the 'dna-admin' directory, execute `rails s` and enter http://localhost:3000 in your browser.  
+You should see a product listing with images.
+
+Enter http://localhost:3000/admin in your browser and log in with spree@example.com/spree123 or with whatever you chose for the admin user. You can manage the system here.
 
-We have language bindings in Shell, Ruby, Python, and JavaScript! You can view code examples in the dark area to the right, and you can switch the programming language of the examples with the tabs in the top right.
+Next move into the 'dna-api' directory and execute:  
 
-This example API documentation page was created with [Slate](https://github.com/lord/slate). Feel free to edit it and use it as a base for your own API's documentation.
+`PORT=3001 rails s`  
 
-# Authentication
+and enter http://localhost:3001 in your browser - this will show the 'index' page.  
 
-> To authorize, use this code:
+You can enter `rails routes` on the command line to see which routes the API supports. On of them is `GET v1/products`, so we can enter in the browser:
 
-```ruby
-require 'kittn'
+`http://localhost:3001/v1/products`
 
-api = Kittn::APIClient.authorize!('meowmeowmeow')
-```
+to get a complete listing of products from the Spree product catalog. The reason why this work is simply a "resource route" definition for Products in `config/routes.rb`, which then generates a set of CRUD routes on the product table.
 
-```python
-import kittn
-
-api = kittn.authorize('meowmeowmeow')
-```
-
-```shell
-# With shell, you can just pass the correct header with each request
-curl "api_endpoint_here"
-  -H "Authorization: meowmeowmeow"
-```
-
-```javascript
-const kittn = require('kittn');
-
-let api = kittn.authorize('meowmeowmeow');
-```
-
-> Make sure to replace `meowmeowmeow` with your API key.
-
-Kittn uses API keys to allow access to the API. You can register a new Kittn API key at our [developer portal](http://example.com/developers).
-
-Kittn expects for the API key to be included in all API requests to the server in a header that looks like the following:
-
-`Authorization: meowmeowmeow`
-
-<aside class="notice">
-You must replace <code>meowmeowmeow</code> with your personal API key.
-</aside>
-
-# Kittens
-
-## Get All Kittens
-
-```ruby
-require 'kittn'
-
-api = Kittn::APIClient.authorize!('meowmeowmeow')
-api.kittens.get
-```
-
-```python
-import kittn
-
-api = kittn.authorize('meowmeowmeow')
-api.kittens.get()
-```
-
-```shell
-curl "http://example.com/api/kittens"
-  -H "Authorization: meowmeowmeow"
-```
-
-```javascript
-const kittn = require('kittn');
-
-let api = kittn.authorize('meowmeowmeow');
-let kittens = api.kittens.get();
-```
-
-> The above command returns JSON structured like this:
-
-```json
-[
-  {
-    "id": 1,
-    "name": "Fluffums",
-    "breed": "calico",
-    "fluffiness": 6,
-    "cuteness": 7
-  },
-  {
-    "id": 2,
-    "name": "Max",
-    "breed": "unknown",
-    "fluffiness": 5,
-    "cuteness": 10
-  }
-]
-```
-
-This endpoint retrieves all kittens.
-
-### HTTP Request
-
-`GET http://example.com/api/kittens`
-
-### Query Parameters
-
-Parameter | Default | Description
---------- | ------- | -----------
-include_cats | false | If set to true, the result will also include cats.
-available | true | If set to false, the result will include kittens that have already been adopted.
-
-<aside class="success">
-Remember — a happy kitten is an authenticated kitten!
-</aside>
-
-## Get a Specific Kitten
-
-```ruby
-require 'kittn'
-
-api = Kittn::APIClient.authorize!('meowmeowmeow')
-api.kittens.get(2)
-```
-
-```python
-import kittn
-
-api = kittn.authorize('meowmeowmeow')
-api.kittens.get(2)
-```
-
-```shell
-curl "http://example.com/api/kittens/2"
-  -H "Authorization: meowmeowmeow"
-```
-
-```javascript
-const kittn = require('kittn');
-
-let api = kittn.authorize('meowmeowmeow');
-let max = api.kittens.get(2);
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": 2,
-  "name": "Max",
-  "breed": "unknown",
-  "fluffiness": 5,
-  "cuteness": 10
-}
-```
-
-This endpoint retrieves a specific kitten.
-
-<aside class="warning">Inside HTML code blocks like this one, you can't use Markdown, so use <code>&lt;code&gt;</code> blocks to denote code.</aside>
-
-### HTTP Request
-
-`GET http://example.com/kittens/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the kitten to retrieve
-
-## Delete a Specific Kitten
-
-```ruby
-require 'kittn'
-
-api = Kittn::APIClient.authorize!('meowmeowmeow')
-api.kittens.delete(2)
-```
-
-```python
-import kittn
-
-api = kittn.authorize('meowmeowmeow')
-api.kittens.delete(2)
-```
-
-```shell
-curl "http://example.com/api/kittens/2"
-  -X DELETE
-  -H "Authorization: meowmeowmeow"
-```
-
-```javascript
-const kittn = require('kittn');
-
-let api = kittn.authorize('meowmeowmeow');
-let max = api.kittens.delete(2);
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": 2,
-  "deleted" : ":("
-}
-```
-
-This endpoint deletes a specific kitten.
-
-### HTTP Request
-
-`DELETE http://example.com/kittens/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the kitten to delete
 


### PR DESCRIPTION
This is the first version of the Slate docs for DNA (Asana ticket: https://app.asana.com/0/1111903910959616/1118328999483697).

At this moment, it just covers local installation on a development system, without using Docker. For now this is probably enough, but going forward we might want to cover:

- installation on Heroku (staging, prod, ...)
- a version of local installation utilizing Docker (the Docker script would have to be created first)
- we might want to cover some sysadmin/management topics as the ones described in the Slate docs for Enchanted, see: https://github.com/EnchantedODIC/docs/blob/master/source/index.html.md

NOTE:

In conjunction with these docs, I've made some changes in other DNA repos:

- dna-database 
- dna-api

In these repos I've also made a "slate-docs" branch with a PR (so we have 3 PR's in total, on the "slated-docs" branches of the various repos). The other 2 PR's simply refer to this PR.

The changes in the other 2 PR's are mainly the addition of an ".env.example" file which supports the installation process.